### PR TITLE
gradient now does not slide up on landscape mode

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -165,9 +165,9 @@ const Page = styled.div`
     background: linear-gradient(60deg, rgba(16, 8, 23, 92.5%), #100817);
     display: block;
     content: '';
-    height: 100vh;
+    height: 100%;
     width: 100%;
-    position: absolute;
+    position: fixed;
     top: 0;
     left: 0;
     z-index: -1;


### PR DESCRIPTION
Gradient slid up on landscape mode when the content was bigger than 100% of the screen. Changing position to fixed got rid of the problem

https://www.notion.so/daopanel/Gradient-sliding-over-background-image-on-mobile-landscape-mode-4da2f3fb99114d96b086cc0526474c0d