### PR TITLE
Notifications demo

### DIFF
--- a/src/components/Conversation.tsx
+++ b/src/components/Conversation.tsx
@@ -1,17 +1,22 @@
 import { useCallback, useEffect } from 'react';
 import styled from 'styled-components';
-import { useXmtpConversation } from 'hooks';
+import { usePreviousVal, useXmtpConversation } from 'hooks';
 import { useEnsName } from 'wagmi';
 import Text from './Text';
 import { useRouter } from 'next/router';
 import Avatar from './Avatar';
 import MobileLoadingText from 'components/MobileLoadingText';
 import { Message } from '@xmtp/xmtp-js';
-
+import type { FetchEnsNameResult } from '@wagmi/core';
 interface ConversationProps {
   peerAddress: string;
   show: boolean;
-  onLoadedOrNewMessage: (peerAddress: string, messages: Message[]) => unknown;
+  onLoadedOrNewMessage: (
+    ensName: FetchEnsNameResult | undefined,
+    peerAddress: string,
+    messages: Message[],
+    prevMessagesCount: number
+  ) => unknown;
 }
 
 export default function Conversation(props: ConversationProps) {
@@ -21,6 +26,7 @@ export default function Conversation(props: ConversationProps) {
   const { data: ensName, isLoading } = useEnsName({
     address: props.peerAddress,
   });
+  const prevMessagesCount = usePreviousVal(messages.length);
   const lastMessage = messages[messages.length - 1];
   const router = useRouter();
 
@@ -30,7 +36,12 @@ export default function Conversation(props: ConversationProps) {
 
   useEffect(() => {
     if (!isConversationLoading) {
-      props.onLoadedOrNewMessage(props.peerAddress, messages);
+      props.onLoadedOrNewMessage(
+        ensName,
+        props.peerAddress,
+        messages,
+        prevMessagesCount ? prevMessagesCount : 0
+      );
     }
     // We don't actually care about messages changing, but there's probably a
     // better way.

--- a/src/components/CreateNewConversation.tsx
+++ b/src/components/CreateNewConversation.tsx
@@ -102,7 +102,7 @@ const HeadlineContainer = styled.div`
 `;
 const Headline = styled.h2`
   font-weight: 400;
-  font-family: Montserrat;
+  font-family: ${({ theme }) => theme.fontFamily.Montserrat};
   font-size: 24px;
   color: #dad0e5;
   order: 1;
@@ -113,7 +113,7 @@ const Headline = styled.h2`
 `;
 
 const UserInput = styled.input`
-  font-family: Montserrat;
+  font-family: ${({ theme }) => theme.fontFamily.Montserrat};
   font-weight: bold;
   border: none;
   font-size: 24px;
@@ -168,7 +168,7 @@ const ButtonText = styled.span`
   color: #dad0e5;
   margin-right: 21px;
   transition: color 400ms;
-  font-family: Montserrat;
+  font-family: ${({ theme }) => theme.fontFamily.Montserrat};
   min-width: max-content;
 `;
 

--- a/src/components/MessageBubble.tsx
+++ b/src/components/MessageBubble.tsx
@@ -27,7 +27,7 @@ const TextWrapper = styled.div`
 
 const MessageText = styled.p`
   color: white;
-  font-family: 'Montserrat';
+  font-family: ${({ theme }) => theme.fontFamily.Montserrat};
   font-style: normal;
   font-weight: 400;
   font-size: 18px;

--- a/src/components/MessageInput.tsx
+++ b/src/components/MessageInput.tsx
@@ -72,7 +72,7 @@ const StyledInput = styled.input`
   }
   color: white;
   font-size: 18px;
-  font-family: Inter;
+  font-family: ${({ theme }) => theme.fontFamily.Inter};
 `;
 
 export default MessageInput;

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -5,3 +5,8 @@ export * from './useXmtpConversations';
 export * from './useRouterEnsData';
 export * from './useWindowSize';
 export * from './useIsMetaMask';
+
+import useActiveTab from './useActiveTab';
+import usePreviousVal from './usePreviousVal';
+
+export { useActiveTab, usePreviousVal };

--- a/src/hooks/useActiveTab.ts
+++ b/src/hooks/useActiveTab.ts
@@ -1,0 +1,20 @@
+import { useCallback, useEffect, useState } from 'react';
+
+const useActiveTab = () => {
+  const [visibilityState, setVisibilityState] = useState(true);
+
+  const handleVisibilityChange = useCallback(() => {
+    setVisibilityState(document.visibilityState === 'visible');
+  }, []);
+
+  useEffect(() => {
+    document.addEventListener('visibilitychange', handleVisibilityChange);
+    return () => {
+      document.removeEventListener('visibilitychange', handleVisibilityChange);
+    };
+  }, [handleVisibilityChange]);
+
+  return { visibilityState };
+};
+
+export default useActiveTab;

--- a/src/hooks/usePreviousVal.ts
+++ b/src/hooks/usePreviousVal.ts
@@ -1,0 +1,12 @@
+import { useRef, useEffect } from 'react';
+
+const usePreviousVal = (value: any) => {
+  const ref = useRef();
+  useEffect(() => {
+    ref.current = value;
+  }, [value]);
+
+  return ref.current;
+};
+
+export default usePreviousVal;

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -13,6 +13,7 @@ import {
 import { CoinbaseWalletConnector } from 'wagmi/connectors/coinbaseWallet';
 import { InjectedConnector } from 'wagmi/connectors/injected';
 import { WalletConnectConnector } from 'wagmi/connectors/walletConnect';
+import { useEffect } from 'react';
 
 const alchemyKey = 'kmMb00nhQ0SWModX6lJLjXy_pVtiQnjx';
 
@@ -55,6 +56,35 @@ const wagmi = createClient({
 });
 
 export default function App({ Component, pageProps }: AppProps) {
+  // checking for notifications at the Top Level
+  useEffect(() => {
+    const CheckForNotification = async () => {
+      if (!('Notification' in window)) {
+        alert('This browser does not support desktop notification');
+      } else {
+        if (Notification.permission === 'default') {
+          Notification.requestPermission()
+            .then(function (p) {
+              if (p === 'granted') {
+                // case when user has granted permission, after clicking on the notification
+              } else {
+                //case when user has denied permission, after clicking on the notification
+                console.log('User blocked notifications.');
+              }
+            })
+            .catch(function (err) {
+              console.error(err);
+            });
+        } else if (Notification.permission === 'granted') {
+          // Case when notification is already granted
+        } else {
+          // Case when notification is denied
+        }
+        // request permission from user
+      }
+    };
+    CheckForNotification();
+  }, []);
   return (
     <ThemeProvider theme={theme}>
       <WagmiProvider client={wagmi}>


### PR DESCRIPTION
This PR is demo & addresses notifications for Chrome feature.

User will receive notifications whenever they have our web app open in background(hello tab is not active). The reason for this approach is that notifications might get annoying for users when the hello app tab is active & they keep pouring in, they might get overwhelmed. It's more like a UX choice that I found to be a good practise. We can change this it if we need to.

Notification work for for Conversations List and Chat pages, preview is below:

https://user-images.githubusercontent.com/7856573/171008759-97581027-eb07-44e6-83bd-919705b09796.mov



https://user-images.githubusercontent.com/7856573/171008675-e122b504-7d4b-400e-8c14-6b3b2843e7da.mov






Some interesting sources found during development:

https://docs.google.com/document/d/1WNPIS_2F0eyDm5SS2E6LZ_75tk6XtBSnR1xNjWJ_DPE

https://www.toptal.com/designers/ux/notification-design