### PR TITLE
Feature/mobile scrolling

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "npm": "^8.7.0",
     "react": "17.0.2",
     "react-blockies": "^1.4.1",
+    "react-device-detect": "2.2.2",
     "react-dom": "17.0.2",
     "react-i18next": "^11.16.7",
     "styled-components": "^5.3.5",

--- a/src/components/Conversations.tsx
+++ b/src/components/Conversations.tsx
@@ -127,7 +127,7 @@ const List = styled.ul`
 
 const Page = styled.div`
   width: 100vw;
-  height: 100vh;
+  height: 100%;
 `;
 
 const Centered = styled.div`

--- a/src/components/MobileConversationsHeader.tsx
+++ b/src/components/MobileConversationsHeader.tsx
@@ -15,37 +15,24 @@ export default function MobileConversationsHeader(
 ) {
   return (
     <MobileFixedHeader>
-      <FullWidthFlexRow>
-        <ClickableImage
-          src={MobileMenu}
-          alt="menu"
-          width={30}
-          height={30}
-          onClick={props.onClickMenu}
-        />
-        <ActiveCategory>{props.activeCategory}</ActiveCategory>
-        <ClickableImage
-          src={NewConversation}
-          alt="menu"
-          width={20}
-          height={20}
-          onClick={props.onClickNewConversation}
-        />
-      </FullWidthFlexRow>
+      <ClickableImage
+        src={MobileMenu}
+        alt="menu"
+        width={30}
+        height={30}
+        onClick={props.onClickMenu}
+      />
+      <ActiveCategory>{props.activeCategory}</ActiveCategory>
+      <ClickableImage
+        src={NewConversation}
+        alt="menu"
+        width={20}
+        height={20}
+        onClick={props.onClickNewConversation}
+      />
     </MobileFixedHeader>
   );
 }
-
-const FullWidthFlexRow = styled.header`
-  width: 100%;
-  display: flex;
-  flex-direction: row;
-  flex-grow: 1;
-  justify-content: space-between;
-  align-items: center;
-  padding-left: 30px;
-  padding-right: 40px;
-`;
 
 const ActiveCategory = styled.h1`
   color: white;

--- a/src/components/MobileFixedHeader.tsx
+++ b/src/components/MobileFixedHeader.tsx
@@ -1,11 +1,16 @@
 import styled from 'styled-components';
 
 const MobileFixedHeader = styled.header`
-  min-height: 96px;
-  border-bottom: 2px solid #191027;
   width: 100%;
   display: flex;
+  flex-direction: row;
+  justify-content: space-between;
   align-items: center;
+  padding-left: 30px;
+  padding-right: 40px;
+  height: 96px;
+  border-bottom: 2px solid #191027;
+  background-color: ${({ theme }) => theme.colors.darkPurple};
 `;
 
 export default MobileFixedHeader;

--- a/src/components/MobileLoadingMessages.tsx
+++ b/src/components/MobileLoadingMessages.tsx
@@ -1,8 +1,19 @@
+import { useEffect, useRef } from 'react';
 import styled from 'styled-components';
 
-export default function MobileLoadingMessages() {
+export default function MobileLoadingMessages({
+  isMobile,
+}: {
+  isMobile: boolean;
+}) {
+  const divScrollToRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    if (!divScrollToRef.current) return;
+    divScrollToRef.current.scrollIntoView({ behavior: 'smooth' });
+  }, []);
   return (
-    <MainContainer>
+    <MainContainer isMobile={isMobile}>
       <LeftContainer>
         <LeftUserInfo>
           <LogoOutline />
@@ -45,19 +56,22 @@ export default function MobileLoadingMessages() {
           <SecondMessage />
         </RightBottomMessageContainer>
       </RightContainer>
+      <div ref={divScrollToRef} />
     </MainContainer>
   );
 }
 
-const MainContainer = styled.div`
+const MainContainer = styled.div<{ isMobile: boolean }>`
   color: white;
-  height: 100%;
+  height: ${({ isMobile }) =>
+    isMobile ? 'calc(100vh - 240px)' : 'calc(100vh - 164px);'};
   width: 100%;
   display: flex;
   flex-direction: column;
   gap: 0px;
   padding: 20px;
   overflow: scroll;
+  z-index: 1000;
 
   @keyframes slide {
     0% {

--- a/src/components/MobileMenu.tsx
+++ b/src/components/MobileMenu.tsx
@@ -226,8 +226,7 @@ const FullHeightSlider = styled.div<StyleProps>`
   width: 90vw;
   height: 100vh;
   background: #2e2043;
-  z-index: 1;
-  left: -90vw;
+  z-index: 100;
   left: ${({ showMenu }) => (showMenu ? '0vw' : '-90vw')};
   visibility: auto;
   visibility: ${({ showMenu }) => (showMenu ? 'auto' : 'hidden')};

--- a/src/components/MobileMessageInput.tsx
+++ b/src/components/MobileMessageInput.tsx
@@ -5,10 +5,11 @@ import TrashCang from '../../public/assets/images/MobileTrashCan';
 import React, { useCallback } from 'react';
 
 interface MessageInputProps {
+  isMobile: boolean;
   onSendMessage: (val: string) => unknown;
 }
 
-const MessageInput = ({ onSendMessage }: MessageInputProps) => {
+const MessageInput = ({ isMobile, onSendMessage }: MessageInputProps) => {
   const [inputVal, setInputVal] = useState<string>('');
 
   const clearInput = useCallback(() => {
@@ -42,7 +43,7 @@ const MessageInput = ({ onSendMessage }: MessageInputProps) => {
         value={inputVal}
         onChange={handleChange}
         onKeyDown={handleKeyDown}
-        autoFocus={true}
+        autoFocus={!isMobile}
       />
       <SvgContainer inputTextCount={inputTextCount} onClick={clearInput}>
         <TrashCang />

--- a/src/components/MobileMessagesHeader.tsx
+++ b/src/components/MobileMessagesHeader.tsx
@@ -12,35 +12,22 @@ interface MobileMessageHeaderProps {
 export default function MobileMessagesHeader(props: MobileMessageHeaderProps) {
   return (
     <MobileFixedHeader>
-      <Header>
-        <Menu
-          width={30}
-          height={30}
-          src={'/assets/images/MobileWhiteHamburgerMenu.svg'}
-          onClick={props.onMenuClick}
-        />
-        <UserDisplay>{shortAddress(props.peerAddressOrName)}</UserDisplay>
-        <GoBack
-          width={20}
-          height={20}
-          src={ArrowLeftWhite}
-          onClick={props.onBackClick}
-        />
-      </Header>
+      <Menu
+        width={30}
+        height={30}
+        src={'/assets/images/MobileWhiteHamburgerMenu.svg'}
+        onClick={props.onMenuClick}
+      />
+      <UserDisplay>{shortAddress(props.peerAddressOrName)}</UserDisplay>
+      <GoBack
+        width={20}
+        height={20}
+        src={ArrowLeftWhite}
+        onClick={props.onBackClick}
+      />
     </MobileFixedHeader>
   );
 }
-
-const Header = styled.header`
-  width: 100%;
-  display: flex;
-  flex-direction: row;
-  justify-content: space-between;
-  align-items: center;
-  padding-left: 30px;
-  padding-right: 40px;
-  height: 68px;
-`;
 
 const UserDisplay = styled.h1`
   font-style: normal;

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -5,3 +5,7 @@ export * from './useXmtpConversations';
 export * from './useRouterEnsData';
 export * from './useWindowSize';
 export * from './useIsMetaMask';
+
+import useDeviceDetect from './useDeviceDetect';
+
+export { useDeviceDetect };

--- a/src/hooks/useDeviceDetect.ts
+++ b/src/hooks/useDeviceDetect.ts
@@ -1,0 +1,21 @@
+import { useState, useEffect } from 'react';
+
+export default function useDeviceDetect() {
+  const [isMobile, setMobile] = useState(false);
+
+  useEffect(() => {
+    const userAgent =
+      typeof window.navigator === 'undefined' ? '' : navigator.userAgent;
+
+    const mobile = Boolean(
+      (userAgent.match(
+        /Android|iPhone|iPad|iPod|Opera Mini|IEMobile|WPDesktop/i
+      ) &&
+        localStorage.mobile) ||
+        window.navigator.maxTouchPoints > 1
+    );
+    setMobile(mobile);
+  }, []);
+
+  return { isMobile };
+}

--- a/src/styles/global.ts
+++ b/src/styles/global.ts
@@ -98,6 +98,7 @@ article, aside, details, figcaption, figure, footer, header, hgroup, menu, nav, 
 body {
   background: #100817;
   line-height: 1;
+  overflow-y: hidden;
 }
 ol,
 ul {


### PR DESCRIPTION
This PR addresses Mobile scrolling issue and couple bugs that were present for mobile screen(mostly)

- [x] Scrolling fix when new messages come in.
- [x] Header not showing fix.
- [x] Refactored conversations and Messages page.
- [x] Keyboard is hiding header on Mobile.
- [x] Hiding input when XMTP client needs to be initialized.
- [x] “Resolves ENS name” height overflow fix.
- [x] Autofocus disabled for mobile.
- [x] Scroll to bottom of the page added for loading messages screen.

